### PR TITLE
python-socketio 5.16.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,29 @@
 {% set name = "python-socketio" %}
-{% set version = "5.15.0" %}
+{% set version = "5.16.3" %}
  
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: d0403ababb59aa12fd5adcfc933a821113f27bd77761bc1c54aad2e3191a9b69
+  sha256: 89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  skip: true  # [py<38]
 
 requirements:
   host:
-    - python
     - pip
-    - setuptools >=61.2
+    - python
     - wheel
+    - setuptools >=61.2
   run:
     - python
-    - python-engineio >=4.11.0
     - bidict >=0.21.0
+    - python-engineio >=4.13.2
   run_constrained:
     - requests >=2.21.0
     - websocket-client >=0.54.0


### PR DESCRIPTION
python-socketio 5.16.3 

**Destination channel:** Defaults

### Links

- [PKG-16451]
- dev_url:        https://github.com/miguelgrinberg/python-socketio/tree/v5.16.3
- conda_forge:    https://github.com/conda-forge/python-socketio-feedstock
- pypi:           https://pypi.org/project/python-socketio/5.16.3
- pypi inspector: https://inspector.pypi.io/project/python-socketio/5.16.3

### Explanation of changes:

- new version number


[PKG-16451]: https://anaconda.atlassian.net/browse/PKG-16451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ